### PR TITLE
dos: Implement palette support

### DIFF
--- a/src/video/svga/SDL_svga_vbe.h
+++ b/src/video/svga/SDL_svga_vbe.h
@@ -160,7 +160,8 @@ extern int SVGA_GetState(void **state);
 extern int SVGA_SetState(const void *state, size_t size);
 extern int SVGA_SetDisplayStart(int x, int y);
 extern int SVGA_SetDACPaletteFormat(int bits);
-extern int SVGA_GetPaletteData(SDL_Color * colors, int num_colors);
+extern int SVGA_GetPaletteData(SDL_Color * colors, int num_colors, Uint8 palette_dac_bits);
+extern int SVGA_SetPaletteData(SDL_Color *colors, int num_colors, Uint8 palette_dac_bits);
 extern SDL_PixelFormatEnum SVGA_GetPixelFormat(const VBEModeInfo * info);
 
 #endif /* SDL_svga_vbe_h_ */

--- a/src/video/svga/SDL_svga_video.h
+++ b/src/video/svga/SDL_svga_video.h
@@ -43,9 +43,12 @@ typedef struct
 
 typedef struct
 {
-    SDL_bool framebuffer_page;
-    int framebuffer_selector;
+    SDL_Palette *last_palette;
+    Uint32 last_palette_version;
     Uint32 framebuffer_linear_addr;
+    int framebuffer_selector;
+    SDL_bool framebuffer_page;
+    Uint8 palette_dac_bits;
 } SDL_WindowData;
 
 #endif /* SDL_svga_video_h_ */


### PR DESCRIPTION
Implements palette video output support.

If the VBE does not support 8-bit DAC, falls back to 6 colors per channel, which actually looks pretty good in Diablo (I can't even tell the difference).

I asked on the dosbox forum about their `svga_s3` video card not supporting 8-bit DAC.

https://www.vogons.org/viewtopic.php?t=108037

/cc @jayschwa 