### PR TITLE
Change return to continue on SVGA mode info error

### DIFF
--- a/src/video/svga/SDL_svga_video.c
+++ b/src/video/svga/SDL_svga_video.c
@@ -159,7 +159,7 @@ SVGA_GetDisplayModes(_THIS, SDL_VideoDisplay * display)
 
         if (status) {
             SDL_LogError(SDL_LOG_CATEGORY_VIDEO, "SVGA_GetVBEModeInfo failed: %d", status);
-            return;
+            continue;
         }
 
         /* Mode must support graphics with a linear framebuffer. */


### PR DESCRIPTION
This allows S3 trio video cards to work

Some cards (ATI) can appear to hang but will eventually get though the list, but that should probably be addressed separately.