### PR TITLE
dos: Use protected-mode interface to set palette

### DIFF
--- a/src/video/svga/SDL_svga_framebuffer.c
+++ b/src/video/svga/SDL_svga_framebuffer.c
@@ -200,6 +200,8 @@ SDL_SVGA_DestroyFramebuffer(_THIS, SDL_Window * window)
         __dpmi_free_physical_address_mapping(&meminfo);
         windata->framebuffer_linear_addr = 0;
     }
+
+    windata->last_palette = NULL;
 }
 
 #endif /* SDL_VIDEO_DRIVER_SVGA */

--- a/src/video/svga/SDL_svga_vbe.h
+++ b/src/video/svga/SDL_svga_vbe.h
@@ -151,6 +151,7 @@ SDL_COMPILE_TIME_ASSERT(VBEModeInfo, sizeof(VBEModeInfo) == 256);
 #define VBE_MEM_MODEL_DIRECT    6
 #define VBE_MEM_MODEL_YUV       7
 
+extern int SVGA_InitProtectedModeInterface();
 extern int SVGA_GetVBEInfo(VBEInfo * info);
 extern VBEMode SVGA_GetVBEModeAtIndex(const VBEInfo * info, int index);
 extern int SVGA_GetVBEModeInfo(VBEMode mode, VBEModeInfo * info);

--- a/src/video/svga/SDL_svga_video.c
+++ b/src/video/svga/SDL_svga_video.c
@@ -58,6 +58,11 @@ SVGA_CreateDevice(void)
     SDL_VideoDevice *device;
     SDL_DeviceData *devdata;
 
+    if (SVGA_InitProtectedModeInterface()) {
+        SDL_LogError(SDL_LOG_CATEGORY_VIDEO, "SVGA: Failed to get protected mode interface");
+        return NULL;
+    }
+
     devdata = (SDL_DeviceData *) SDL_calloc(1, sizeof(*devdata));
     if (!devdata) {
         SDL_OutOfMemory();


### PR DESCRIPTION
Calling out via real-mode bridge would kill performance when color cycling.

Luckily, VBE 2.0 provides protected mode interface for some of the functions, and setting the palette is one of them.

The asm code is based on Allegro 4.2 `vesa_set_palette_range`. Luckily, Allegro license is extremely permissive.
